### PR TITLE
Add event logging

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+language: php
+matrix:
+  include:
+    - php: '5.3'
+      env:
+        - TEST_SUITE='no_psalm'
+    - php: '5.4'
+      env:
+        - TEST_SUITE='no_psalm'
+    - php: '5.5'
+      env:
+        - TEST_SUITE='no_psalm'
+    - php: '5.6'
+      env:
+        - TEST_SUITE='with_psalm'
+        - COMPOSER='composer-psalm.json'
+    - php: '7.0'
+      env:
+        - TEST_SUITE='with_psalm'
+        - COMPOSER='composer-psalm.json'
+    - php: '7.1'
+      env:
+        - TEST_SUITE='with_psalm'
+        - COMPOSER='composer-psalm.json'
+install: composer install
+script: make $TEST_SUITE
+dist: precise
+notifications:
+  email: false

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Vimeo, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ style:
 	vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpcs --standard=PSR2 --error-severity=1 --warning-severity=6 tests
 
 test:
-	vendor/bin/phpunit
+	vendor/bin/phpunit tests
 
 psalm:
 	vendor/bin/psalm

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+# Test
+
+all: with_psalm
+
+no_psalm: style test
+
+with_psalm: style psalm test
+
+style:
+	vendor/bin/phpcs --standard=PSR2 src && vendor/bin/phpcs --standard=PSR2 --error-severity=1 --warning-severity=6 tests
+
+test:
+	vendor/bin/phpunit
+
+psalm:
+	vendor/bin/psalm
+
+# Install
+
+install: install_with_psalm
+
+install_with_psalm:
+	COMPOSER=composer-psalm.json php composer.phar install
+
+install_no_psalm:
+	php composer.phar install
+
+# Update
+
+update: update_with_psalm
+
+update_with_psalm:
+	COMPOSER=composer-psalm.json php composer.phar update
+
+update_no_psalm:
+	php composer.phar update

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Logging capabilities for Omnipay gateways via an `EventSubscriberInterface` subscriber for Omnipay payment gateway-specific events.
 These events are dispatched via the HTTP client's `EventDispatcherInterface`.
 * The omnipay gateway needs to be updated to emit any of the `RequestEvent`, `ResponseEvent` or `ErrorEvent` objects.
-For example in the gateway's`sendData()` methods we can do:
+For example in the gateway's `sendData()` methods we can do:
 
     ```PHP
     $event_dispatcher = $this->httpClient->getEventDispatcher();
@@ -11,7 +11,7 @@ For example in the gateway's`sendData()` methods we can do:
     Logging Errors and Responses events can be emitted like so
     ```PHP
     $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception));
-    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_SUCCESS, new ResponseEvent($response));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE_SUCCESS, new ResponseEvent($response));
     ```
 
 `OmnipayGatewayRequestSubscriber.php` takes in a logger of type `LoggerInterface` which will listen to and log these events.
@@ -19,8 +19,8 @@ For example in the gateway's`sendData()` methods we can do:
 The subscriber can be set up  to listen to these events when instantiating the HTTP client for the gateway like so:
 
 ```PHP
-$client = new GuzzleClient();
-$gateway = new VindiciaOmnipayGateway($client);
-$eventDispatcher = $client->getEventDispatcher();
+$httpClient = new GuzzleClient();
+$gateway = Omnipay::create('Vindicia', $httpClient);
+$eventDispatcher = $httpClient->getEventDispatcher();
 $eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsInterface()));
 ```

--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
-Logging capabilities for Omnipay gateways
+Logging capabilities for Omnipay gateways via an `EventSubscriberInterface` subscriber for Omnipay payment gateway-specific events.
+These events are dispatched via the HTTP client's `EventDispatcherInterface`.
+* The omnipay gateway needs to be updated to emit any of the `RequestEvent`, `ResponseEvent` or `ErrorEvent` objects.
+For example in the gateway's`sendData()` methods we can do:
+
+    ```PHP
+    $event_dispatcher = $this->httpClient->getEventDispatcher();
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_BEFORE_SEND, new RequestEvent($request));
+    ```
+
+    Logging Errors and Responses events can be emitted like so
+    ```PHP
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_SUCCESS, new ResponseEvent($response));
+    ```
+
+`OmnipayGatewayRequestSubscriber.php` takes in a logger of type `LoggerInterface` which will listen to and log these events.
+
+The subscriber can be set up  to listen to these events when instantiating the HTTP client for the gateway like so:
+
+```PHP
+$client = new GuzzleClient();
+$gateway = new VindiciaOmnipayGateway($client);
+$eventDispatcher = $client->getEventDispatcher();
+$eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsInterface()));

--- a/README.md
+++ b/README.md
@@ -23,3 +23,4 @@ $client = new GuzzleClient();
 $gateway = new VindiciaOmnipayGateway($client);
 $eventDispatcher = $client->getEventDispatcher();
 $eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsInterface()));
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+Logging capabilities for Omnipay gateways

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "guzzle/guzzle": "^3.9",
-        "omnipay/common": "~2.0",
-        "psr/log": "^1.1"
+        "psr/log": "^1.0",
+        "omnipay/common": "~2.0"
     },
     "require-dev": {
         "vimeo/psalm": "0.3.*",

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -20,9 +20,7 @@
         "omnipay/common": "~2.0"
     },
     "require-dev": {
-        "vimeo/psalm": "0.3.*",
-        "phpunit/phpunit": "^4",
-        "mockery/mockery": "^0.9.11",
-        "squizlabs/php_codesniffer": "1.5"
+        "omnipay/tests": "~2.0",
+        "vimeo/psalm": "0.3.*"
     }
 }

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "vimeo/psalm": "0.3.*",
         "phpunit/phpunit": "^4",
-        "mockery/mockery": "^0.9.11"
+        "mockery/mockery": "^0.9.11",
+        "squizlabs/php_codesniffer": "1.5"
     }
 }

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -20,6 +20,7 @@
         "psr/log": "^1.1"
     },
     "require-dev": {
+        "vimeo/psalm": "0.3.*",
         "phpunit/phpunit": "^4",
         "mockery/mockery": "^0.9.11"
     }

--- a/composer-psalm.json
+++ b/composer-psalm.json
@@ -11,7 +11,8 @@
     ],
      "autoload": {
         "psr-4": {
-            "PaymentGatewayLogger\\" : "src/"
+            "PaymentGatewayLogger\\" : "src/",
+            "PaymentGatewayLogger\\Test\\" : "tests/"
         }
     },
     "require": {

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^4",
-        "mockery/mockery": "^0.9.11"
+        "mockery/mockery": "^0.9.11",
+        "vimeo/psalm": "^3.2"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -20,8 +20,6 @@
         "omnipay/common": "~2.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4",
-        "mockery/mockery": "^0.9.11",
-        "squizlabs/php_codesniffer": "1.5"
+        "omnipay/tests": "~2.0"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,7 @@
     "require-dev": {
         "phpunit/phpunit": "^4",
         "mockery/mockery": "^0.9.11",
-        "vimeo/psalm": "^3.2"
+        "vimeo/psalm": "^3.2",
+        "squizlabs/php_codesniffer": "1.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "guzzle/guzzle": "^3.9",
-        "omnipay/common": "~2.0",
-        "psr/log": "^1.1"
+        "psr/log": "1.0.0",
+        "omnipay/common": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4",

--- a/composer.json
+++ b/composer.json
@@ -9,12 +9,18 @@
             "email": "juan.manzo@vimeo.com"
         }
     ],
+     "autoload": {
+        "psr-4": {
+            "PaymentGatewayLogger\\" : "src/"
+        }
+    },
     "require": {
         "guzzle/guzzle": "^3.9",
         "omnipay/common": "~2.0",
         "psr/log": "^1.1"
     },
     "require-dev": {
-        "vimeo/psalm": "^3.2"
+        "vimeo/psalm": "^3.2",
+        "phpunit/phpunit": "^4"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,11 @@
             "email": "juan.manzo@vimeo.com"
         }
     ],
-    "require": {},
+    "require": {
+        "guzzle/guzzle": "^3.9",
+        "omnipay/common": "~2.0",
+        "psr/log": "^1.1"
+    },
     "require-dev": {
         "vimeo/psalm": "^3.2"
     }

--- a/composer.json
+++ b/composer.json
@@ -9,5 +9,8 @@
             "email": "juan.manzo@vimeo.com"
         }
     ],
-    "require": {}
+    "require": {},
+    "require-dev": {
+        "vimeo/psalm": "^3.2"
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,6 @@
     "require-dev": {
         "phpunit/phpunit": "^4",
         "mockery/mockery": "^0.9.11",
-        "vimeo/psalm": "^3.2",
         "squizlabs/php_codesniffer": "1.5"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
     },
     "require-dev": {
         "vimeo/psalm": "^3.2",
-        "phpunit/phpunit": "^4"
+        "phpunit/phpunit": "^4",
+        "mockery/mockery": "^0.9.11"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,8 @@
     ],
      "autoload": {
         "psr-4": {
-            "PaymentGatewayLogger\\" : "src/"
+            "PaymentGatewayLogger\\" : "src/",
+            "PaymentGatewayLogger\\Test\\" : "tests/"
         }
     },
     "require": {

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<psalm
+    totallyTyped="false"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="https://getpsalm.org/schema/config"
+    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
+>
+    <projectFiles>
+        <directory name="src" />
+        <ignoreFiles>
+            <directory name="vendor" />
+        </ignoreFiles>
+    </projectFiles>
+
+    <issueHandlers>
+        <LessSpecificReturnType errorLevel="info" />
+
+        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
+
+        <DeprecatedMethod errorLevel="info" />
+        <DeprecatedProperty errorLevel="info" />
+        <DeprecatedClass errorLevel="info" />
+        <DeprecatedConstant errorLevel="info" />
+        <DeprecatedInterface errorLevel="info" />
+        <DeprecatedTrait errorLevel="info" />
+
+        <InternalMethod errorLevel="info" />
+        <InternalProperty errorLevel="info" />
+        <InternalClass errorLevel="info" />
+
+        <MissingClosureReturnType errorLevel="info" />
+        <MissingReturnType errorLevel="info" />
+        <MissingPropertyType errorLevel="info" />
+        <InvalidDocblock errorLevel="info" />
+        <MisplacedRequiredParam errorLevel="info" />
+
+        <PropertyNotSetInConstructor errorLevel="info" />
+        <MissingConstructor errorLevel="info" />
+        <MissingClosureParamType errorLevel="info" />
+        <MissingParamType errorLevel="info" />
+
+        <RedundantCondition errorLevel="info" />
+
+        <DocblockTypeContradiction errorLevel="info" />
+        <RedundantConditionGivenDocblockType errorLevel="info" />
+
+        <UnresolvableInclude errorLevel="info" />
+
+        <RawObjectIteration errorLevel="info" />
+
+        <InvalidStringClass errorLevel="info" />
+    </issueHandlers>
+</psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -11,43 +11,4 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
-
-    <issueHandlers>
-        <LessSpecificReturnType errorLevel="info" />
-
-        <!-- level 3 issues - slightly lazy code writing, but provably low false-negatives -->
-
-        <DeprecatedMethod errorLevel="info" />
-        <DeprecatedProperty errorLevel="info" />
-        <DeprecatedClass errorLevel="info" />
-        <DeprecatedConstant errorLevel="info" />
-        <DeprecatedInterface errorLevel="info" />
-        <DeprecatedTrait errorLevel="info" />
-
-        <InternalMethod errorLevel="info" />
-        <InternalProperty errorLevel="info" />
-        <InternalClass errorLevel="info" />
-
-        <MissingClosureReturnType errorLevel="info" />
-        <MissingReturnType errorLevel="info" />
-        <MissingPropertyType errorLevel="info" />
-        <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
-
-        <PropertyNotSetInConstructor errorLevel="info" />
-        <MissingConstructor errorLevel="info" />
-        <MissingClosureParamType errorLevel="info" />
-        <MissingParamType errorLevel="info" />
-
-        <RedundantCondition errorLevel="info" />
-
-        <DocblockTypeContradiction errorLevel="info" />
-        <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <UnresolvableInclude errorLevel="info" />
-
-        <RawObjectIteration errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
-    </issueHandlers>
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,14 +1,53 @@
 <?xml version="1.0"?>
 <psalm
-    totallyTyped="false"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xmlns="https://getpsalm.org/schema/config"
-    xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
->
-    <projectFiles>
-        <directory name="src" />
-        <ignoreFiles>
-            <directory name="vendor" />
-        </ignoreFiles>
-    </projectFiles>
+    name="Psalm for Payment gateway logger driver"
+    useDocblockTypes="true"
+    >
+  <projectFiles>
+    <directory name="src" />
+    <directory name="tests" />
+  </projectFiles>
+
+  <fileExtensions>
+    <extension name=".php" />
+  </fileExtensions>
+
+  <issueHandlers>
+    <MixedArgument errorLevel="suppress" />
+    <MixedMethodCall errorLevel="suppress" />
+    <MixedPropertyFetch errorLevel="suppress" />
+    <MixedPropertyAssignment errorLevel="suppress" />
+    <MixedInferredReturnType errorLevel="suppress" />
+    <MixedArrayAccess errorLevel="suppress" />
+
+    <!-- Psalm doesn't like that initialize() sets instance variables for the constructor -->
+    <PropertyNotSetInConstructor errorLevel="suppress" />
+
+    <!-- Unit tests set lots of instance variables inline -->
+    <UndefinedThisPropertyAssignment>
+      <errorLevel type="suppress">
+        <directory name="tests" />
+      </errorLevel>
+    </UndefinedThisPropertyAssignment>
+    <MissingPropertyType>
+      <errorLevel type="suppress">
+        <directory name="tests" />
+      </errorLevel>
+    </MissingPropertyType>
+    <InaccessibleProperty>
+      <errorLevel type="suppress">
+        <directory name="tests" />
+      </errorLevel>
+    </InaccessibleProperty>
+    <TooManyArguments>
+      <errorLevel type="suppress">
+        <directory name="tests" />
+      </errorLevel>
+    </TooManyArguments>
+  </issueHandlers>
+
+  <mockClasses>
+    <class name="Mockery\MockInterface" />
+  </mockClasses>
+
 </psalm>

--- a/psalm.xml
+++ b/psalm.xml
@@ -44,6 +44,16 @@
         <directory name="tests" />
       </errorLevel>
     </TooManyArguments>
+    <MissingClosureReturnType>
+       <errorLevel type="suppress">
+        <file name="src/TestLogger.php" />
+      </errorLevel>
+    </MissingClosureReturnType>
+    <MissingClosureParamType>
+       <errorLevel type="suppress">
+        <file name="src/TestLogger.php" />
+      </errorLevel>
+    </MissingClosureParamType>
   </issueHandlers>
 
   <mockClasses>

--- a/src/Event/Constants.php
+++ b/src/Event/Constants.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Event;
+
+/**
+ * Class events.
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+final class Constants
+{
+    const OMNIPAY_REQUEST = 'omnipay.request.before_send';
+    const OMNIPAY_RESPONSE = 'omnipay.request.sent';
+    const OMNIPAY_ERROR = 'omnipay.request.error';
+}

--- a/src/Event/Constants.php
+++ b/src/Event/Constants.php
@@ -13,6 +13,6 @@ namespace PaymentGatewayLogger\Event;
 final class Constants
 {
     const OMNIPAY_REQUEST_BEFORE_SEND = 'omnipay.request.before_send';
-    const OMNIPAY_REQUEST_SUCCESS = 'omnipay.request.sent';
+    const OMNIPAY_RESPONSE_SUCCESS = 'omnipay.response.success';
     const OMNIPAY_REQUEST_ERROR = 'omnipay.request.error';
 }

--- a/src/Event/Constants.php
+++ b/src/Event/Constants.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Event;
+namespace PaymentGatewayLogger\Event;
 
 /**
  * Class events.

--- a/src/Event/Constants.php
+++ b/src/Event/Constants.php
@@ -12,7 +12,7 @@ namespace PaymentGatewayLogger\Event;
 
 final class Constants
 {
-    const OMNIPAY_REQUEST = 'omnipay.request.before_send';
-    const OMNIPAY_RESPONSE = 'omnipay.request.sent';
-    const OMNIPAY_ERROR = 'omnipay.request.error';
+    const OMNIPAY_REQUEST_BEFORE_SEND = 'omnipay.request.before_send';
+    const OMNIPAY_REQUEST_SUCCESS = 'omnipay.request.sent';
+    const OMNIPAY_REQUEST_ERROR = 'omnipay.request.error';
 }

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Error event to be used by the payment gateway logger.
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+namespace PaymentGatewayLogger\Event;
+
+use Exception;
+use Guzzle\Common\Event;
+
+class ErrorEvent extends Event
+{
+    /**
+     * @var Exception
+     */
+    protected $error;
+
+    /**
+     * @var string
+     */
+    protected $type = Constants::OMNIPAY_ERROR;
+
+    /**
+     * @param Exception $error
+     */
+    public function __construct($error)
+    {
+        $this->error = $error;
+
+        parent::__construct(array('error' => $error));
+    }
+
+    /**
+     * @return Exception
+     */
+    public function getContext()
+    {
+        return $this->error;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -22,7 +22,7 @@ class ErrorEvent extends Event
     /**
      * @var string
      */
-    protected $type = Constants::OMNIPAY_ERROR;
+    protected $type = Constants::OMNIPAY_REQUEST_ERROR;
 
     /**
      * @param Exception $error

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -20,11 +20,6 @@ class ErrorEvent extends Event
     protected $error;
 
     /**
-     * @var string
-     */
-    protected $type = Constants::OMNIPAY_REQUEST_ERROR;
-
-    /**
      * @param Exception $error
      */
     public function __construct($error)
@@ -47,6 +42,6 @@ class ErrorEvent extends Event
      */
     public function getType()
     {
-        return $this->type;
+        return Constants::OMNIPAY_REQUEST_ERROR;
     }
 }

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -22,7 +22,7 @@ class RequestEvent extends Event
     /**
      * @var string
      */
-    protected $type = Constants::OMNIPAY_REQUEST;
+    protected $type = Constants::OMNIPAY_REQUEST_BEFORE_SEND;
 
     /**
      * @param RequestInterface $request

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Request event to be used by the payment gateway logger.
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+namespace PaymentGatewayLogger\Event;
+
+use Guzzle\Common\Event;
+use Omnipay\Common\Message\RequestInterface;
+
+class RequestEvent extends Event
+{
+    /**
+     * @var RequestInterface
+     */
+    protected $request;
+
+    /**
+     * @var string
+     */
+    protected $type = Constants::OMNIPAY_REQUEST;
+
+    /**
+     * @param RequestInterface $request
+     */
+    public function __construct($request)
+    {
+        $this->request = $request;
+
+        parent::__construct(array('request' => $request));
+    }
+
+    /**
+     * @return RequestInterface
+     */
+    public function getContext()
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -20,11 +20,6 @@ class RequestEvent extends Event
     protected $request;
 
     /**
-     * @var string
-     */
-    protected $type = Constants::OMNIPAY_REQUEST_BEFORE_SEND;
-
-    /**
      * @param RequestInterface $request
      */
     public function __construct($request)
@@ -47,6 +42,6 @@ class RequestEvent extends Event
      */
     public function getType()
     {
-        return $this->type;
+        return Constants::OMNIPAY_REQUEST_BEFORE_SEND;
     }
 }

--- a/src/Event/ResponseEvent.php
+++ b/src/Event/ResponseEvent.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * Response event to be used by the payment gateway logger.
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+namespace PaymentGatewayLogger\Event;
+
+use Guzzle\Common\Event;
+use Omnipay\Common\Message\ResponseInterface;
+
+class ResponseEvent extends Event
+{
+    /**
+     * @var ResponseInterface
+     */
+    protected $response;
+
+    /**
+     * @var string
+     */
+    protected $type = Constants::OMNIPAY_RESPONSE;
+
+    /**
+     * @param ResponseInterface $response
+     */
+    public function __construct($response)
+    {
+        $this->response = $response;
+
+        parent::__construct(array('response' => $response));
+    }
+
+    /**
+     * @return ResponseInterface
+     */
+    public function getContext()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+}

--- a/src/Event/ResponseEvent.php
+++ b/src/Event/ResponseEvent.php
@@ -22,7 +22,7 @@ class ResponseEvent extends Event
     /**
      * @var string
      */
-    protected $type = Constants::OMNIPAY_RESPONSE;
+    protected $type = Constants::OMNIPAY_REQUEST_SUCCESS;
 
     /**
      * @param ResponseInterface $response

--- a/src/Event/ResponseEvent.php
+++ b/src/Event/ResponseEvent.php
@@ -20,11 +20,6 @@ class ResponseEvent extends Event
     protected $response;
 
     /**
-     * @var string
-     */
-    protected $type = Constants::OMNIPAY_REQUEST_SUCCESS;
-
-    /**
      * @param ResponseInterface $response
      */
     public function __construct($response)
@@ -47,6 +42,6 @@ class ResponseEvent extends Event
      */
     public function getType()
     {
-        return $this->type;
+        return Constants::OMNIPAY_RESPONSE_SUCCESS;
     }
 }

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -62,9 +62,9 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return array(
-            Constants::OMNIPAY_REQUEST  => array('onOmnipayRequestBeforeSend', self::PRIORITY),
-            Constants::OMNIPAY_RESPONSE => array('onOmnipayRequestSent', self::PRIORITY),
-            Constants::OMNIPAY_ERROR    => array('onOmnipayRequestError', self::PRIORITY),
+            Constants::OMNIPAY_REQUEST_BEFORE_SEND  => array('onOmnipayRequestBeforeSend', self::PRIORITY),
+            Constants::OMNIPAY_REQUEST_SUCCESS => array('onOmnipaySuccessfulResponse', self::PRIORITY),
+            Constants::OMNIPAY_REQUEST_ERROR    => array('onOmnipayRequestError', self::PRIORITY),
         );
     }
 
@@ -93,7 +93,7 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      * @param Event $event
      * @return void
      */
-    public function onOmnipayRequestSent(Event $event)
+    public function onOmnipaySuccessfulResponse(Event $event)
     {
         $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
     }

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -63,7 +63,7 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     {
         return array(
             Constants::OMNIPAY_REQUEST_BEFORE_SEND  => array('onOmnipayRequestBeforeSend', self::PRIORITY),
-            Constants::OMNIPAY_REQUEST_SUCCESS => array('onOmnipaySuccessfulResponse', self::PRIORITY),
+            Constants::OMNIPAY_RESPONSE_SUCCESS => array('onOmnipayResponseSuccess', self::PRIORITY),
             Constants::OMNIPAY_REQUEST_ERROR    => array('onOmnipayRequestError', self::PRIORITY),
         );
     }
@@ -93,7 +93,7 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      * @param Event $event
      * @return void
      */
-    public function onOmnipaySuccessfulResponse(Event $event)
+    public function onOmnipayResponseSuccess(Event $event)
     {
         $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
     }

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -17,7 +17,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
 {
-    const PRIORITY = 255;
+    const PRIORITY = 0;
 
     /**
      * @var LoggerInterface

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -7,11 +7,10 @@
  * @version    1
  */
 
-namespace Event\Subscriber;
+namespace PaymentGatewayLogger\Event\Subscriber;
 
-
-use Event\Constants;
 use Guzzle\Common\Event;
+use PaymentGatewayLogger\Event\Constants;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * payment-gateway-logger
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+namespace Event\Subscriber;
+
+
+use Event\Constants;
+use Guzzle\Common\Event;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
+{
+    const PRIORITY = 255;
+
+    /**
+     * @var LoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var string
+     */
+    private $gateway_name;
+
+    /**
+     * OmnipayGatewayRequestSubscriber constructor.
+     *
+     * @param string $gateway_name
+     * @param LoggerInterface $logger
+     */
+    public function __construct($gateway_name, $logger)
+    {
+        $this->logger = $logger;
+        $this->gateway_name = 'omnipay_' . $gateway_name;
+    }
+
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * The array keys are event names and the value can be:
+     *
+     *  * The method name to call (priority defaults to 0)
+     *  * An array composed of the method name to call and the priority
+     *  * An array of arrays composed of the method names to call and respective
+     *    priorities, or 0 if unset
+     *
+     * For instance:
+     *
+     *  * array('eventName' => 'methodName')
+     *  * array('eventName' => array('methodName', $priority))
+     *  * array('eventName' => array(array('methodName1', $priority), array('methodName2')))
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            Constants::OMNIPAY_REQUEST  => array('onOmnipayRequestBeforeSend', self::PRIORITY),
+            Constants::OMNIPAY_RESPONSE => array('onOmnipayRequestSent', self::PRIORITY),
+            Constants::OMNIPAY_ERROR    => array('onOmnipayRequestError', self::PRIORITY),
+        );
+    }
+
+    /**
+     * Triggers a log write before a request is sent.
+     *
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayRequestBeforeSend(Event $event)
+    {
+        $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
+    }
+
+    /**
+     * Triggers a log write when a request completes.
+     *
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayRequestSent(Event $event)
+    {
+        $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
+    }
+
+    /**
+     * Triggers a log write when a request fails.
+     *
+     * @param Event $event
+     * @return void
+     */
+    public function onOmnipayRequestError(Event $event)
+    {
+        $this->logger->log(LogLevel::ERROR, $this->gateway_name, $event->toArray());
+    }
+}

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -71,6 +71,10 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     /**
      * Triggers a log write before a request is sent.
      *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'request' => \Omnipay\Common\Message\AbstractRequest
+     *     )
      * @param Event $event
      * @return void
      */
@@ -82,6 +86,10 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     /**
      * Triggers a log write when a request completes.
      *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'response' => \Omnipay\Common\Message\AbstractResponse
+     *     )
      * @param Event $event
      * @return void
      */
@@ -93,6 +101,10 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     /**
      * Triggers a log write when a request fails.
      *
+     * The event will be converted to an array before being logged. It will contain the following properties:
+     *     array(
+     *         'error' => Exception
+     *     )
      * @param Event $event
      * @return void
      */

--- a/src/TestFramework/TestLogger.php
+++ b/src/TestFramework/TestLogger.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace PaymentGatewayLogger\TestFramework;
+
+use Psr\Log\AbstractLogger;
+
+/**
+ * Pulled from https://github.com/php-fig/log/ modified for php >= 5.3
+ *
+ * Used for testing purposes.
+ *
+ * It records all records and gives you access to them for verification.
+ *
+ * @method bool hasEmergency($record)
+ * @method bool hasAlert($record)
+ * @method bool hasCritical($record)
+ * @method bool hasError($record)
+ * @method bool hasWarning($record)
+ * @method bool hasNotice($record)
+ * @method bool hasInfo($record)
+ * @method bool hasDebug($record)
+ *
+ * @method bool hasEmergencyRecords()
+ * @method bool hasAlertRecords()
+ * @method bool hasCriticalRecords()
+ * @method bool hasErrorRecords()
+ * @method bool hasWarningRecords()
+ * @method bool hasNoticeRecords()
+ * @method bool hasInfoRecords()
+ * @method bool hasDebugRecords()
+ *
+ * @method bool hasEmergencyThatContains($message)
+ * @method bool hasAlertThatContains($message)
+ * @method bool hasCriticalThatContains($message)
+ * @method bool hasErrorThatContains($message)
+ * @method bool hasWarningThatContains($message)
+ * @method bool hasNoticeThatContains($message)
+ * @method bool hasInfoThatContains($message)
+ * @method bool hasDebugThatContains($message)
+ *
+ * @method bool hasEmergencyThatMatches($message)
+ * @method bool hasAlertThatMatches($message)
+ * @method bool hasCriticalThatMatches($message)
+ * @method bool hasErrorThatMatches($message)
+ * @method bool hasWarningThatMatches($message)
+ * @method bool hasNoticeThatMatches($message)
+ * @method bool hasInfoThatMatches($message)
+ * @method bool hasDebugThatMatches($message)
+ *
+ * @method bool hasEmergencyThatPasses($message)
+ * @method bool hasAlertThatPasses($message)
+ * @method bool hasCriticalThatPasses($message)
+ * @method bool hasErrorThatPasses($message)
+ * @method bool hasWarningThatPasses($message)
+ * @method bool hasNoticeThatPasses($message)
+ * @method bool hasInfoThatPasses($message)
+ * @method bool hasDebugThatPasses($message)
+ */
+class TestLogger extends AbstractLogger
+{
+    /**
+     * @var array
+     */
+    public $records = array();
+
+    public $recordsByLevel = array();
+
+    /**
+     * @inheritdoc
+     */
+    public function log($level, $message, array $context = array())
+    {
+        $record = array(
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        );
+
+        $this->recordsByLevel[$record['level']][] = $record;
+        $this->records[] = $record;
+    }
+
+    public function hasRecords($level)
+    {
+        return isset($this->recordsByLevel[$level]);
+    }
+
+    public function hasRecord($record, $level)
+    {
+        if (is_string($record)) {
+            $record = array('message' => $record);
+        }
+        return $this->hasRecordThatPasses(function ($rec) use ($record) {
+            if ($rec['message'] !== $record['message']) {
+                return false;
+            }
+            if (isset($record['context']) && $rec['context'] !== $record['context']) {
+                return false;
+            }
+            return true;
+        }, $level);
+    }
+
+    public function hasRecordThatContains($message, $level)
+    {
+        return $this->hasRecordThatPasses(function ($rec) use ($message) {
+            return strpos($rec['message'], $message) !== false;
+        }, $level);
+    }
+
+    public function hasRecordThatMatches($regex, $level)
+    {
+        return $this->hasRecordThatPasses(function ($rec) use ($regex) {
+            return preg_match($regex, $rec['message']) > 0;
+        }, $level);
+    }
+
+    public function hasRecordThatPasses($predicate, $level)
+    {
+        if (!isset($this->recordsByLevel[$level])) {
+            return false;
+        }
+        foreach ($this->recordsByLevel[$level] as $i => $rec) {
+            if (call_user_func($predicate, $rec, $i)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function __call($method, $args)
+    {
+        if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
+            $genericMethod = $matches[1] . ('Records' !== $matches[3] ? 'Record' : '') . $matches[3];
+            $level = strtolower($matches[2]);
+            if (method_exists($this, $genericMethod)) {
+                $args[] = $level;
+                return call_user_func_array(array($this, $genericMethod), $args);
+            }
+        }
+        throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
+    }
+
+    public function reset()
+    {
+        $this->records = array();
+    }
+}

--- a/src/TestFramework/TestLogger.php
+++ b/src/TestFramework/TestLogger.php
@@ -63,6 +63,9 @@ class TestLogger extends AbstractLogger
      */
     public $records = array();
 
+    /**
+     * @var array
+     */
     public $recordsByLevel = array();
 
     /**
@@ -80,16 +83,28 @@ class TestLogger extends AbstractLogger
         $this->records[] = $record;
     }
 
+    /**
+     * @param $level
+     *
+     * @return bool
+     */
     public function hasRecords($level)
     {
         return isset($this->recordsByLevel[$level]);
     }
 
+    /**
+     * @param $record
+     * @param $level
+     *
+     * @return bool
+     */
     public function hasRecord($record, $level)
     {
         if (is_string($record)) {
             $record = array('message' => $record);
         }
+
         return $this->hasRecordThatPasses(function ($rec) use ($record) {
             if ($rec['message'] !== $record['message']) {
                 return false;
@@ -101,6 +116,12 @@ class TestLogger extends AbstractLogger
         }, $level);
     }
 
+    /**
+     * @param $message
+     * @param $level
+     *
+     * @return bool
+     */
     public function hasRecordThatContains($message, $level)
     {
         return $this->hasRecordThatPasses(function ($rec) use ($message) {
@@ -108,6 +129,12 @@ class TestLogger extends AbstractLogger
         }, $level);
     }
 
+    /**
+     * @param $regex
+     * @param $level
+     *
+     * @return bool
+     */
     public function hasRecordThatMatches($regex, $level)
     {
         return $this->hasRecordThatPasses(function ($rec) use ($regex) {
@@ -115,6 +142,12 @@ class TestLogger extends AbstractLogger
         }, $level);
     }
 
+    /**
+     * @param $predicate
+     * @param $level
+     *
+     * @return bool
+     */
     public function hasRecordThatPasses($predicate, $level)
     {
         if (!isset($this->recordsByLevel[$level])) {
@@ -128,6 +161,12 @@ class TestLogger extends AbstractLogger
         return false;
     }
 
+    /**
+     * @param $method
+     * @param $args
+     *
+     * @return mixed
+     */
     public function __call($method, $args)
     {
         if (preg_match('/(.*)(Debug|Info|Notice|Warning|Error|Critical|Alert|Emergency)(.*)/', $method, $matches) > 0) {
@@ -141,6 +180,9 @@ class TestLogger extends AbstractLogger
         throw new \BadMethodCallException('Call to undefined method ' . get_class($this) . '::' . $method . '()');
     }
 
+    /**
+     * @return void
+     */
     public function reset()
     {
         $this->records = array();

--- a/tests/Framework/TestLogger.php
+++ b/tests/Framework/TestLogger.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace PaymentGatewayLogger\TestFramework;
+namespace PaymentGatewayLogger\Test\Framework;
 
 use Psr\Log\AbstractLogger;
 

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -13,9 +13,9 @@ use PaymentGatewayLogger\Event\ErrorEvent;
 use PaymentGatewayLogger\Event\RequestEvent;
 use PaymentGatewayLogger\Event\ResponseEvent;
 use PaymentGatewayLogger\Event\Subscriber\OmnipayGatewayRequestSubscriber;
+use PaymentGatewayLogger\TestFramework\TestLogger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
-use Psr\Log\Test\TestLogger;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace PaymentGatewayLogger;
+
+use Mockery;
+use Guzzle\Common\Event;
+use Guzzle\Http\Client;
+use PaymentGatewayLogger\Event\ErrorEvent;
+use PaymentGatewayLogger\Event\RequestEvent;
+use PaymentGatewayLogger\Event\ResponseEvent;
+use PaymentGatewayLogger\Event\Subscriber\OmnipayGatewayRequestSubscriber;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LogLevel;
+use Psr\Log\Test\TestLogger;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+/**
+ * payment-gateway-logger
+ *
+ * @package    payment-gateway-logger
+ * @author     manzoj
+ * @version    1
+ */
+
+class OmnipayGatewayRequestSubscriberTest extends TestCase
+{
+    /**
+     * @var EventDispatcher
+     */
+    private $eventDispatcher;
+    /**
+     * @var OmnipayGatewayRequestSubscriber
+     */
+    private $subscriber;
+
+    /**
+     * @var TestLogger
+     */
+    private $logger;
+
+    protected function setUp()
+    {
+        $httpClient = new Client();
+        $this->eventDispatcher = $httpClient->getEventDispatcher();
+        $this->logger = new TestLogger();
+        $this->subscriber = new OmnipayGatewayRequestSubscriber('test', $this->logger);
+
+        parent::setUp();
+    }
+
+    public function providerLoggingEvents()
+    {
+        $request = Mockery::mock('Omnipay\Common\Message\RequestInterface');
+        $response = Mockery::mock('Omnipay\Common\Message\ResponseInterface');
+        $exception = Mockery::mock('Exception');
+
+        $requestEvent = new RequestEvent($request);
+        $responseEvent = new ResponseEvent($response);
+        $errorEvent = new ErrorEvent($exception);
+
+        $requestRecord = array(
+            'level' => LogLevel::INFO,
+            'message' => 'omnipay_test',
+            'context' => $requestEvent->toArray(),
+        );
+        $responseRecord = array(
+            'level' => LogLevel::INFO,
+            'message' => 'omnipay_test',
+            'context' => $responseEvent->toArray(),
+        );
+        $errorRecord = array(
+            'level' => LogLevel::ERROR,
+            'message' => 'omnipay_test',
+            'context' => $errorEvent->toArray(),
+        );
+
+        return array(
+            array($requestEvent->getType(), $requestEvent, $requestRecord),
+            array($responseEvent->getType(), $responseEvent, $responseRecord),
+            array($errorEvent->getType(), $errorEvent, $errorRecord),
+        );
+    }
+
+
+    /**
+     * @dataProvider providerLoggingEvents
+     *
+     * @param string $event_type
+     * @param Event $event
+     * @param array $record
+     */
+    public function testLogging($event_type, $event, array $record)
+    {
+        $this->eventDispatcher->addSubscriber($this->subscriber);
+        $this->eventDispatcher->dispatch($event_type, $event);
+
+        if ($record['level'] === LogLevel::INFO) {
+            $this->assertTrue($this->logger->hasInfoRecords());
+            $this->assertTrue($this->logger->hasInfo($record));
+        }
+        else if ($record['level'] === LogLevel::ERROR) {
+            $this->assertTrue($this->logger->hasErrorRecords());
+            $this->assertTrue($this->logger->hasError($record));
+        }
+    }
+}
+
+

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -98,15 +98,11 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         if ($record['level'] === LogLevel::INFO) {
             $this->assertTrue($this->logger->hasInfoRecords());
             $this->assertTrue($this->logger->hasInfo($record));
-        }
-        else if ($record['level'] === LogLevel::ERROR) {
+        } else if ($record['level'] === LogLevel::ERROR) {
             $this->assertTrue($this->logger->hasErrorRecords());
             $this->assertTrue($this->logger->hasError($record));
-        }
-        else {
+        } else {
             throw new InvalidArgumentException('Logging level has invalid type');
         }
     }
 }
-
-

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -13,7 +13,7 @@ use PaymentGatewayLogger\Event\ErrorEvent;
 use PaymentGatewayLogger\Event\RequestEvent;
 use PaymentGatewayLogger\Event\ResponseEvent;
 use PaymentGatewayLogger\Event\Subscriber\OmnipayGatewayRequestSubscriber;
-use PaymentGatewayLogger\TestFramework\TestLogger;
+use PaymentGatewayLogger\Test\Framework\TestLogger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -2,10 +2,13 @@
 
 namespace PaymentGatewayLogger;
 
+use Exception;
 use InvalidArgumentException;
-use Mockery;
 use Guzzle\Common\Event;
 use Guzzle\Http\Client;
+use Mockery;
+use Omnipay\Common\Message\RequestInterface;
+use Omnipay\Common\Message\ResponseInterface;
 use PaymentGatewayLogger\Event\ErrorEvent;
 use PaymentGatewayLogger\Event\RequestEvent;
 use PaymentGatewayLogger\Event\ResponseEvent;
@@ -13,7 +16,7 @@ use PaymentGatewayLogger\Event\Subscriber\OmnipayGatewayRequestSubscriber;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\LogLevel;
 use Psr\Log\Test\TestLogger;
-use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * payment-gateway-logger
@@ -26,7 +29,7 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
 class OmnipayGatewayRequestSubscriberTest extends TestCase
 {
     /**
-     * @var EventDispatcher
+     * @var EventDispatcherInterface
      */
     private $eventDispatcher;
     /**
@@ -39,6 +42,9 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
      */
     private $logger;
 
+    /**
+     * @return void
+     */
     protected function setUp()
     {
         $httpClient = new Client();
@@ -49,10 +55,18 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         parent::setUp();
     }
 
+    /**
+     * @return array
+     */
     public function providerLoggingEvents()
     {
+        /** @var RequestInterface $request */
         $request = Mockery::mock('Omnipay\Common\Message\RequestInterface');
+
+        /** @var ResponseInterface $response */
         $response = Mockery::mock('Omnipay\Common\Message\ResponseInterface');
+
+        /** @var Exception $exception */
         $exception = Mockery::mock('Exception');
 
         $requestEvent = new RequestEvent($request);
@@ -89,6 +103,8 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
      * @param string $event_type
      * @param Event $event
      * @param array $record
+     *
+     * @return void
      */
     public function testLogging($event_type, $event, array $record)
     {

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -2,6 +2,7 @@
 
 namespace PaymentGatewayLogger;
 
+use InvalidArgumentException;
 use Mockery;
 use Guzzle\Common\Event;
 use Guzzle\Http\Client;
@@ -101,6 +102,9 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         else if ($record['level'] === LogLevel::ERROR) {
             $this->assertTrue($this->logger->hasErrorRecords());
             $this->assertTrue($this->logger->hasError($record));
+        }
+        else {
+            throw new InvalidArgumentException('Logging level has invalid type');
         }
     }
 }


### PR DESCRIPTION
* Adds an `EventSubscriberInterface` subscriber for Omnipay payment gateway specific events.
* Both `omnipay-vindicia` and `omnipay-bluesnap` `sendData()` methods will need to be updated to emit these events in this file `/src/Event/Constants.php` in order for the subscriber to log these requests.  For example a request can be logged before it's sent like so:

    ```PHP
    $event_dispatcher = $this->httpClient->getEventDispatcher();
    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST, new RequestEvent($request));
    ```

    Logging Errors and Responses events can be emitted like so
    ```PHP
    $event_dispatcher->dispatch(Constants::OMNIPAY_ERROR new ErrorEvent($exception));
    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE, new ResponseEvent($response));
    ```

`OmnipayGatewayRequestSubscriber.php` takes in a logger of type `LoggerInterface` which will listen to and log these events.

The subscriber can be set up  to listen to these events when instantiating the HTTP client for the gateway like so:

```PHP
$client = new GuzzleClient();
$gateway = new VindiciaOmnipayGateway($client);
$eventDispatcher = $client->getEventDispatcher();
$eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsInterface()));
```

We don't technically need `OmnipayGatewayRequestSubscriber` to be part of this repo. This can be up to the client to set up but I included it for ease of use. I'm open to removing it and setting this up on the Vimeo side. @nickyr @DanayaMel thoughts?

TODO: 

- [X]  Update README with instructions.
