### PR TITLE
Fix psr log dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     },
     "require": {
         "guzzle/guzzle": "^3.9",
-        "psr/log": "1.0.0",
+        "psr/log": "^1.0",
         "omnipay/common": "~2.0"
     },
     "require-dev": {


### PR DESCRIPTION
When adding this package to the omnipay-vindica package `composer require vimeo/payment-gateway-logger` I found there was a clash with the version of psr/log being installed. payment-gateway-logger with explicitly install version 1.0.0 whereas omnipay-vindicia uses 1.1.0 Here's the error when running composer install

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Can only install one of: psr/log[1.1.0, 1.0.0].
    - Can only install one of: psr/log[1.0.0, 1.1.0].
    - Can only install one of: psr/log[1.0.0, 1.1.0].
    - vimeo/payment-gateway-logger 1.0.0 requires psr/log 1.0.0 -> satisfiable by psr/log[1.0.0].
    - Installation request for vimeo/payment-gateway-logger ^1.0 -> satisfiable by vimeo/payment-gateway-logger[1.0.0].
    - Installation request for psr/log (locked at 1.1.0) -> satisfiable by psr/log[1.1.0].


Installation failed, reverting composer-psalm.json to its original content.
```

This PR changes the psr/log dependency from `1.0.0` to `^1.0` 