### PR TITLE
Update logging methods usage in subscriber

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,15 @@ These events are dispatched via the HTTP client's `EventDispatcherInterface`.
 For example in the gateway's `sendData()` methods we can do:
 
     ```PHP
+    $request_name; // The name of the API endpoint being called
     $event_dispatcher = $this->httpClient->getEventDispatcher();
-    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_BEFORE_SEND, new RequestEvent($request));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_BEFORE_SEND, new RequestEvent($request, $request_name));
     ```
 
     Logging Errors and Responses events can be emitted like so
     ```PHP
-    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception));
-    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE_SUCCESS, new ResponseEvent($response));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception', $request_name));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE_SUCCESS, new ResponseEvent($response, $request_name));
     ```
 
 `OmnipayGatewayRequestSubscriber.php` takes in a logger of type `LoggerInterface` which will listen to and log these events.
@@ -22,5 +23,5 @@ The subscriber can be set up  to listen to these events when instantiating the H
 $httpClient = new GuzzleClient();
 $gateway = Omnipay::create('Vindicia', $httpClient);
 $eventDispatcher = $httpClient->getEventDispatcher();
-$eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsInterface()));
+$eventDispatcher->addSubscriber(new OmnipayGatewayRequestSubscriber($gateway_name, new LoggerClassThatImplementsPSRInterface()));
 ```

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -15,26 +15,12 @@ use Guzzle\Common\Event;
 class ErrorEvent extends Event
 {
     /**
-     * @var Exception
-     */
-    protected $error;
-
-    /**
      * @param Exception $error
+     * @param string    $request_name
      */
-    public function __construct($error)
+    public function __construct($error, $request_name)
     {
-        $this->error = $error;
-
-        parent::__construct(array('error' => $error));
-    }
-
-    /**
-     * @return Exception
-     */
-    public function getContext()
-    {
-        return $this->error;
+        parent::__construct(array('error' => $error, 'request_name' => $request_name));
     }
 
     /**

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -15,26 +15,12 @@ use Omnipay\Common\Message\RequestInterface;
 class RequestEvent extends Event
 {
     /**
-     * @var RequestInterface
-     */
-    protected $request;
-
-    /**
      * @param RequestInterface $request
+     * @param string           $request_name
      */
-    public function __construct($request)
+    public function __construct($request, $request_name)
     {
-        $this->request = $request;
-
-        parent::__construct(array('request' => $request));
-    }
-
-    /**
-     * @return RequestInterface
-     */
-    public function getContext()
-    {
-        return $this->request;
+        parent::__construct(array('request' => $request, 'request_name' => $request_name));
     }
 
     /**

--- a/src/Event/ResponseEvent.php
+++ b/src/Event/ResponseEvent.php
@@ -15,26 +15,12 @@ use Omnipay\Common\Message\ResponseInterface;
 class ResponseEvent extends Event
 {
     /**
-     * @var ResponseInterface
-     */
-    protected $response;
-
-    /**
      * @param ResponseInterface $response
+     * @param string            $request_name
      */
-    public function __construct($response)
+    public function __construct($response, $request_name)
     {
-        $this->response = $response;
-
-        parent::__construct(array('response' => $response));
-    }
-
-    /**
-     * @return ResponseInterface
-     */
-    public function getContext()
-    {
-        return $this->response;
+        parent::__construct(array('response' => $response, 'request_name' => $request_name));
     }
 
     /**

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -12,7 +12,6 @@ namespace PaymentGatewayLogger\Event\Subscriber;
 use Guzzle\Common\Event;
 use PaymentGatewayLogger\Event\Constants;
 use Psr\Log\LoggerInterface;
-use Psr\Log\LogLevel;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -80,7 +80,7 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      */
     public function onOmnipayRequestBeforeSend(Event $event)
     {
-        $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
+        $this->logger->info($this->gateway_name, $event->toArray());
     }
 
     /**
@@ -95,7 +95,7 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      */
     public function onOmnipayResponseSuccess(Event $event)
     {
-        $this->logger->log(LogLevel::INFO, $this->gateway_name, $event->toArray());
+        $this->logger->notice($this->gateway_name, $event->toArray());
     }
 
     /**
@@ -110,6 +110,6 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      */
     public function onOmnipayRequestError(Event $event)
     {
-        $this->logger->log(LogLevel::ERROR, $this->gateway_name, $event->toArray());
+        $this->logger->error($this->gateway_name, $event->toArray());
     }
 }

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -79,7 +79,7 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
             'context' => $requestEvent->toArray(),
         );
         $responseRecord = array(
-            'level' => LogLevel::INFO,
+            'level' => LogLevel::NOTICE,
             'message' => 'omnipay_test',
             'context' => $responseEvent->toArray(),
         );
@@ -114,6 +114,9 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         if ($record['level'] === LogLevel::INFO) {
             $this->assertTrue($this->logger->hasInfoRecords());
             $this->assertTrue($this->logger->hasInfo($record));
+        } else if ($record['level'] === LogLevel::NOTICE) {
+            $this->assertTrue($this->logger->hasNoticeRecords());
+            $this->assertTrue($this->logger->hasNotice($record));
         } else if ($record['level'] === LogLevel::ERROR) {
             $this->assertTrue($this->logger->hasErrorRecords());
             $this->assertTrue($this->logger->hasError($record));

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -3,8 +3,8 @@
 namespace PaymentGatewayLogger;
 
 use Exception;
-use InvalidArgumentException;
 use Guzzle\Common\Event;
+use InvalidArgumentException;
 use Guzzle\Http\Client;
 use Mockery;
 use Omnipay\Common\Message\RequestInterface;
@@ -43,6 +43,11 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
     private $logger;
 
     /**
+     * @var string
+     */
+    private $requestName = 'test_request_name';
+
+    /**
      * @return void
      */
     protected function setUp()
@@ -51,7 +56,6 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         $this->eventDispatcher = $httpClient->getEventDispatcher();
         $this->logger = new TestLogger();
         $this->subscriber = new OmnipayGatewayRequestSubscriber('test', $this->logger);
-
         parent::setUp();
     }
 
@@ -69,9 +73,9 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         /** @var Exception $exception */
         $exception = Mockery::mock('Exception');
 
-        $requestEvent = new RequestEvent($request);
-        $responseEvent = new ResponseEvent($response);
-        $errorEvent = new ErrorEvent($exception);
+        $requestEvent = new RequestEvent($request, $this->requestName);
+        $responseEvent = new ResponseEvent($response, $this->requestName);
+        $errorEvent = new ErrorEvent($exception, $this->requestName);
 
         $requestRecord = array(
             'level' => LogLevel::INFO,
@@ -111,13 +115,19 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         $this->eventDispatcher->addSubscriber($this->subscriber);
         $this->eventDispatcher->dispatch($event_type, $event);
 
+        $context = $event->toArray();
+        $this->assertEquals($this->requestName, $context['request_name']);
+
         if ($record['level'] === LogLevel::INFO) {
+            $this->assertInstanceOf('Omnipay\Common\Message\RequestInterface', $context['request']);
             $this->assertTrue($this->logger->hasInfoRecords());
             $this->assertTrue($this->logger->hasInfo($record));
         } else if ($record['level'] === LogLevel::NOTICE) {
+            $this->assertInstanceOf('Omnipay\Common\Message\ResponseInterface', $context['response']);
             $this->assertTrue($this->logger->hasNoticeRecords());
             $this->assertTrue($this->logger->hasNotice($record));
         } else if ($record['level'] === LogLevel::ERROR) {
+            $this->assertInstanceOf('\Exception', $context['error']);
             $this->assertTrue($this->logger->hasErrorRecords());
             $this->assertTrue($this->logger->hasError($record));
         } else {


### PR DESCRIPTION
* Updates the logging methods invoked in the OmnipayGatewayRequestSubscriber.php to use a different method depending on the type of event. For example.
    * An error event will be logged by calling `error()` in the logger
    * A successful response will be logged via `notice()`. According to the psr logger interface `notice()` is used for "Normal but significant events."
    * A request event event will be logged by calling `info` which according to the psr logger interface is used for "Interesting events." I'd say this fits that.
* I've also updated the `*Events` by removing a lot of logic that wasn't necessary and should be cleaner to use.
* Added support for `*Events` to store the request name in the event context.