### PR TITLE
Event cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,15 +4,14 @@ These events are dispatched via the HTTP client's `EventDispatcherInterface`.
 For example in the gateway's `sendData()` methods we can do:
 
     ```PHP
-    $request_name; // The name of the API endpoint being called
     $event_dispatcher = $this->httpClient->getEventDispatcher();
-    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_BEFORE_SEND, new RequestEvent($request, $request_name));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_BEFORE_SEND, new RequestEvent($request));
     ```
 
     Logging Errors and Responses events can be emitted like so
     ```PHP
-    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception', $request_name));
-    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE_SUCCESS, new ResponseEvent($response, $request_name));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_REQUEST_ERROR new ErrorEvent($exception, $request));
+    $event_dispatcher->dispatch(Constants::OMNIPAY_RESPONSE_SUCCESS, new ResponseEvent($response));
     ```
 
 `OmnipayGatewayRequestSubscriber.php` takes in a logger of type `LoggerInterface` which will listen to and log these events.

--- a/src/Event/Constants.php
+++ b/src/Event/Constants.php
@@ -6,7 +6,6 @@ namespace PaymentGatewayLogger\Event;
  * Class events.
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 

--- a/src/Event/ErrorEvent.php
+++ b/src/Event/ErrorEvent.php
@@ -3,7 +3,6 @@
  * Error event to be used by the payment gateway logger.
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 
@@ -11,16 +10,17 @@ namespace PaymentGatewayLogger\Event;
 
 use Exception;
 use Guzzle\Common\Event;
+use Omnipay\Common\Message\RequestInterface;
 
 class ErrorEvent extends Event
 {
     /**
      * @param Exception $error
-     * @param string    $request_name
+     * @param RequestInterface $request
      */
-    public function __construct($error, $request_name)
+    public function __construct($error, $request)
     {
-        parent::__construct(array('error' => $error, 'request_name' => $request_name));
+        parent::__construct(array('error' => $error, 'request' => $request));
     }
 
     /**

--- a/src/Event/RequestEvent.php
+++ b/src/Event/RequestEvent.php
@@ -3,7 +3,6 @@
  * Request event to be used by the payment gateway logger.
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 
@@ -16,11 +15,10 @@ class RequestEvent extends Event
 {
     /**
      * @param RequestInterface $request
-     * @param string           $request_name
      */
-    public function __construct($request, $request_name)
+    public function __construct($request)
     {
-        parent::__construct(array('request' => $request, 'request_name' => $request_name));
+        parent::__construct(array('request' => $request));
     }
 
     /**

--- a/src/Event/ResponseEvent.php
+++ b/src/Event/ResponseEvent.php
@@ -3,7 +3,6 @@
  * Response event to be used by the payment gateway logger.
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 
@@ -16,11 +15,10 @@ class ResponseEvent extends Event
 {
     /**
      * @param ResponseInterface $response
-     * @param string            $request_name
      */
-    public function __construct($response, $request_name)
+    public function __construct($response)
     {
-        parent::__construct(array('response' => $response, 'request_name' => $request_name));
+        parent::__construct(array('response' => $response));
     }
 
     /**

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -3,7 +3,6 @@
  * payment-gateway-logger
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 

--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -101,7 +101,8 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
      *
      * The event will be converted to an array before being logged. It will contain the following properties:
      *     array(
-     *         'error' => Exception
+     *         'error' => Exception,
+     *         'request' => \Omnipay\Common\Message\AbstractRequest
      *     )
      * @param Event $event
      * @return void

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -22,7 +22,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  * payment-gateway-logger
  *
  * @package    payment-gateway-logger
- * @author     manzoj
  * @version    1
  */
 
@@ -41,11 +40,6 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
      * @var TestLogger
      */
     private $logger;
-
-    /**
-     * @var string
-     */
-    private $requestName = 'test_request_name';
 
     /**
      * @return void
@@ -73,9 +67,9 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         /** @var Exception $exception */
         $exception = Mockery::mock('Exception');
 
-        $requestEvent = new RequestEvent($request, $this->requestName);
-        $responseEvent = new ResponseEvent($response, $this->requestName);
-        $errorEvent = new ErrorEvent($exception, $this->requestName);
+        $requestEvent = new RequestEvent($request);
+        $responseEvent = new ResponseEvent($response);
+        $errorEvent = new ErrorEvent($exception, $request);
 
         $requestRecord = array(
             'level' => LogLevel::INFO,
@@ -116,7 +110,6 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
         $this->eventDispatcher->dispatch($event_type, $event);
 
         $context = $event->toArray();
-        $this->assertEquals($this->requestName, $context['request_name']);
 
         if ($record['level'] === LogLevel::INFO) {
             $this->assertInstanceOf('Omnipay\Common\Message\RequestInterface', $context['request']);

--- a/tests/OmnipayGatewayRequestSubscriberTest.php
+++ b/tests/OmnipayGatewayRequestSubscriberTest.php
@@ -121,6 +121,7 @@ class OmnipayGatewayRequestSubscriberTest extends TestCase
             $this->assertTrue($this->logger->hasNotice($record));
         } else if ($record['level'] === LogLevel::ERROR) {
             $this->assertInstanceOf('\Exception', $context['error']);
+            $this->assertInstanceOf('Omnipay\Common\Message\RequestInterface', $context['request']);
             $this->assertTrue($this->logger->hasErrorRecords());
             $this->assertTrue($this->logger->hasError($record));
         } else {


### PR DESCRIPTION
* I decided to go a different another route (than the change introduced [here](https://github.com/vimeo/payment-gateway-logger/pull/3)) when logging a request's name. It will now instead be up to the client that implements the Logger to determine if and how they want that information logged rather than it being the responsibility of this library.
* Updates the `ErrorEvent` to take in the request object. This is useful so we can get the request name associated with the error event.