### PR TITLE
Make class instance props protected

### DIFF
--- a/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
+++ b/src/Event/Subscriber/OmnipayGatewayRequestSubscriber.php
@@ -20,12 +20,12 @@ class OmnipayGatewayRequestSubscriber implements EventSubscriberInterface
     /**
      * @var LoggerInterface
      */
-    private $logger;
+    protected $logger;
 
     /**
      * @var string
      */
-    private $gateway_name;
+    protected $gateway_name;
 
     /**
      * OmnipayGatewayRequestSubscriber constructor.


### PR DESCRIPTION
* Made `OmnipayGatewayRequestSubscriber.php` instance variables `protected` in order to be able to access them from any child classes.